### PR TITLE
feat: World of Interests & Main Projects layout refinement

### DIFF
--- a/.agent/skills/idan_core_blueprint/SKILL.md
+++ b/.agent/skills/idan_core_blueprint/SKILL.md
@@ -11,7 +11,14 @@ This skill serves as the ultimate Source of Truth for the Creator's identity, pr
 The Creator operates on a philosophy that transcends the sterile division of "biology" and "engineering." Instead, reality is modeled through the lens of Reflection, Flow, and Systemic Sustainability.
 
 ### 1.1 The Infinite Search Fields & The Elemental Anchor
-- **Concept:** The Creator is a multidisciplinary expert who draws from an infinite array of search fields—biological, mathematical, physical, abstract, emotional, motional, neuroscientific, engineering, Kabbalistic, astrological, and numerological. The capacity to cross-reference across this infinity is the core diagnostic strength.
+- **Concept:** The Creator is a multidisciplinary expert who draws from an infinite array of search fields. The capacity to cross-reference across this constellation is the core diagnostic strength. The exact mapped fields include:
+  - Exact Sciences, Life Sciences, Soft Sciences
+  - Engineering, Artificial Intelligence (AI)
+  - Human Mind & Human Experience
+  - Mental Health & Emotional Work
+  - Classical Kabbalah (Zohar, Sefer Yetzira, HaARI)
+  - Practical Kabbalah (Shap-Tie Method)
+  - Astrology & Numerology
 - **The Coalescence:** The Creator's "fields of interest" and "professional fields" coalesce entirely. There is no separation between the spiritual researcher and the AI architect; the multidimensional search fields are the exact engine powering the professional output.
 - **The Alchemical Formula (The Anchor):** To prevent diverging to infinity, this vastness is anchored into a precise elemental logic: Deep **Intuition (Water)** combines with rigorous, multi-domain **Knowledge (Air)**. This synthesis ignites immense **Action (Fire)**, and ultimately, the **Body (Earth)**—the biological and motional reality—feels and holds the absolute truth.
 - **Application:** These fields serve as the **invisible backend reference model**. By mapping human interaction to these fields, the system calculates the precise conditions to facilitate deep flow *without* exhausting the human system.

--- a/.agent/skills/idan_core_blueprint/SKILL.md
+++ b/.agent/skills/idan_core_blueprint/SKILL.md
@@ -16,7 +16,7 @@ The Creator operates on a philosophy that transcends the sterile division of "bi
   - Engineering, Artificial Intelligence (AI)
   - Human Mind & Human Experience
   - Mental Health & Emotional Work
-  - Classical Kabbalah (Zohar, Sefer Yetzira, HaARI)
+  - Classical Kabbalah (Sefer Yetzira, HaARI, Zohar)
   - Practical Kabbalah (Shap-Tie Method)
   - Astrology & Numerology
 - **The Coalescence:** The Creator's "fields of interest" and "professional fields" coalesce entirely. There is no separation between the spiritual researcher and the AI architect; the multidimensional search fields are the exact engine powering the professional output.

--- a/src/components/sections/MainProjects.tsx
+++ b/src/components/sections/MainProjects.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
  * WorkGrid Section - Displays ranked experience and projects.
  * Powered by high-integrity Zod-validated data.
  */
-export default function WorkGrid() {
+export default function MainProjects() {
   const projects = [
     {
       section: "Virgo",
@@ -75,7 +75,7 @@ export default function WorkGrid() {
 
   return (
     <Section id="work" className="space-y-12">
-      <h2 className="text-3xl font-bold text-gradient inline-block">Sovereign Architectures</h2>
+      <h2 className="text-3xl font-bold text-gradient inline-block">Main Projects</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {projects.map((item, index) => {
           const theme = getThemeClasses(item.theme);

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 const KNOWLEDGE_STRUCTURE = [
     {
         title: "The Biological & Behavioral Core",
-        subtitle: "The Source",
+        supTitle: "The Source",
         icon: Activity,
         color: "text-idan-david-aviv-blue",
         bg: "bg-idan-david-aviv-blue/10",
@@ -21,7 +21,7 @@ const KNOWLEDGE_STRUCTURE = [
     },
     {
         title: "The Structural & Systems Core",
-        subtitle: "The Body",
+        supTitle: "The Body",
         icon: Dna,
         color: "text-idan-david-aviv-cyan",
         bg: "bg-idan-david-aviv-cyan/10",
@@ -36,7 +36,7 @@ const KNOWLEDGE_STRUCTURE = [
     },
     {
         title: "The Metaphysical & Diagnostic Core",
-        subtitle: "The Context",
+        supTitle: "The Context",
         icon: Sparkles,
         color: "text-idan-david-aviv-purple",
         bg: "bg-idan-david-aviv-purple/10",
@@ -102,16 +102,16 @@ export default function WorldOfInterests() {
                                         {KNOWLEDGE_STRUCTURE.map((group, idx) => (
                                             <div key={idx} className="flex flex-col space-y-4">
                                                 {/* Group Header */}
-                                                <div className="flex flex-col items-center text-center space-y-2 mb-2">
-                                                    <div className={cn("p-2 rounded-lg mb-1", group.bg, group.border, "border")}>
+                                                <div className="flex flex-col items-center text-center space-y-1 mb-3">
+                                                    <div className={cn("p-2 rounded-lg mb-2", group.bg, group.border, "border")}>
                                                         <group.icon className={cn("w-5 h-5", group.color)} />
                                                     </div>
+                                                    <span className={cn("text-[11px] font-bold tracking-[0.2em] uppercase opacity-80", group.color)}>
+                                                        {group.supTitle}
+                                                    </span>
                                                     <h4 className="text-white/90 font-medium text-[13px] tracking-wide uppercase">
                                                         {group.title}
                                                     </h4>
-                                                    <span className={cn("text-[11px] font-bold tracking-[0.2em] uppercase opacity-80", group.color)}>
-                                                        {group.subtitle}
-                                                    </span>
                                                 </div>
                                                 
                                                 {/* Items List */}

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { ChevronDown, Brain, Dna, Telescope, Sparkles } from 'lucide-react'
+import Section from '@/components/ui/Section'
+import { cn } from '@/lib/utils'
+
+const INTERESTS = [
+    {
+        id: "neuroscience",
+        title: "Biology & Neuroscience",
+        icon: Brain,
+        color: "text-idan-david-aviv-blue",
+        bg: "bg-idan-david-aviv-blue/10",
+        border: "border-idan-david-aviv-blue/20",
+        content: "Understanding the foundational wetware. Exploring neuroplasticity, dopamine regulation, and how biological states govern cognitive output and flow."
+    },
+    {
+        id: "kabbalah",
+        title: "The Shap-Tie Method (Kabbalah)",
+        icon: Sparkles,
+        color: "text-idan-david-aviv-purple",
+        bg: "bg-idan-david-aviv-purple/10",
+        border: "border-idan-david-aviv-purple/20",
+        content: "A systematic approach to breaking down reality into fundamental energetic components. Using ancient structural frameworks as high-level data models for human intuition."
+    },
+    {
+        id: "astrology",
+        title: "Astrology & Cosmic Rhythms",
+        icon: Telescope,
+        color: "text-idan-david-aviv-gold",
+        bg: "bg-idan-david-aviv-gold/10",
+        border: "border-idan-david-aviv-gold/20",
+        content: "Mapping macro-environmental variables. Recognizing the overarching patterns in time that influence micro-interactions, turning intuitive sense into actionable data."
+    },
+    {
+        id: "systems",
+        title: "Deterministic Agentic Systems",
+        icon: Dna,
+        color: "text-idan-david-aviv-cyan",
+        bg: "bg-idan-david-aviv-cyan/10",
+        border: "border-idan-david-aviv-cyan/20",
+        content: "Translating abstract philosophies and chaotic workflows into strict, reliable, and deeply structured autonomous AI architectures."
+    }
+]
+
+export default function WorldOfInterests() {
+    const [openId, setOpenId] = useState<string | null>(null);
+
+    const toggleInterest = (id: string) => {
+        setOpenId(openId === id ? null : id);
+    };
+
+    return (
+        <Section id="world-of-interests" className="pb-32 px-6">
+            <div className="w-full max-w-4xl mx-auto flex flex-col items-center">
+                <div className="text-center mb-12 space-y-4">
+                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight text-white/90">
+                        World of Interests
+                    </h2>
+                    <p className="text-white/50 text-lg font-light max-w-2xl mx-auto">
+                        The multidimensional fields driving the underlying architecture.
+                    </p>
+                </div>
+
+                <div className="w-full space-y-4">
+                    {INTERESTS.map((interest) => (
+                        <div
+                            key={interest.id}
+                            className="w-full rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden transition-all duration-300"
+                        >
+                            <button
+                                onClick={() => toggleInterest(interest.id)}
+                                className={cn(
+                                    "w-full flex items-center justify-between p-6 cursor-pointer hover:bg-white/[0.04] transition-colors",
+                                    openId === interest.id && "bg-white/[0.04]"
+                                )}
+                            >
+                                <div className="flex items-center gap-4">
+                                    <div className={cn("p-3 rounded-xl", interest.bg, interest.border, "border")}>
+                                        <interest.icon className={cn("w-6 h-6", interest.color)} />
+                                    </div>
+                                    <h3 className="text-lg md:text-xl font-medium text-white/90">
+                                        {interest.title}
+                                    </h3>
+                                </div>
+                                <motion.div
+                                    animate={{ rotate: openId === interest.id ? 180 : 0 }}
+                                    transition={{ duration: 0.3 }}
+                                    className="p-2"
+                                >
+                                    <ChevronDown className="w-5 h-5 text-white/40" />
+                                </motion.div>
+                            </button>
+
+                            <AnimatePresence>
+                                {openId === interest.id && (
+                                    <motion.div
+                                        initial={{ height: 0, opacity: 0 }}
+                                        animate={{ height: "auto", opacity: 1 }}
+                                        exit={{ height: 0, opacity: 0 }}
+                                        transition={{ duration: 0.3, ease: "easeInOut" }}
+                                    >
+                                        <div className="p-6 pt-0 text-white/60 leading-relaxed font-light">
+                                            {interest.content}
+                                        </div>
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Section>
+    )
+}

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -1,113 +1,127 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ChevronDown, Brain, Dna, Telescope, Sparkles } from 'lucide-react'
+import { ChevronDown, Brain, Dna, Sparkles, Activity } from 'lucide-react'
 import Section from '@/components/ui/Section'
 import { cn } from '@/lib/utils'
 
-const INTERESTS = [
+const KNOWLEDGE_STRUCTURE = [
     {
-        id: "neuroscience",
-        title: "Biology & Neuroscience",
-        icon: Brain,
+        title: "The Biological & Behavioral Core",
+        icon: Activity,
         color: "text-idan-david-aviv-blue",
         bg: "bg-idan-david-aviv-blue/10",
         border: "border-idan-david-aviv-blue/20",
-        content: "Understanding the foundational wetware. Exploring neuroplasticity, dopamine regulation, and how biological states govern cognitive output and flow."
+        items: [
+            "Life Sciences",
+            "Soft Sciences",
+            "Human Mind & Human Experience",
+            "Mental Health & Emotional Work"
+        ]
     },
     {
-        id: "kabbalah",
-        title: "The Shap-Tie Method (Kabbalah)",
-        icon: Sparkles,
-        color: "text-idan-david-aviv-purple",
-        bg: "bg-idan-david-aviv-purple/10",
-        border: "border-idan-david-aviv-purple/20",
-        content: "A systematic approach to breaking down reality into fundamental energetic components. Using ancient structural frameworks as high-level data models for human intuition."
-    },
-    {
-        id: "astrology",
-        title: "Astrology & Cosmic Rhythms",
-        icon: Telescope,
-        color: "text-idan-david-aviv-gold",
-        bg: "bg-idan-david-aviv-gold/10",
-        border: "border-idan-david-aviv-gold/20",
-        content: "Mapping macro-environmental variables. Recognizing the overarching patterns in time that influence micro-interactions, turning intuitive sense into actionable data."
-    },
-    {
-        id: "systems",
-        title: "Deterministic Agentic Systems",
+        title: "The Structural & Systems Core",
         icon: Dna,
         color: "text-idan-david-aviv-cyan",
         bg: "bg-idan-david-aviv-cyan/10",
         border: "border-idan-david-aviv-cyan/20",
-        content: "Translating abstract philosophies and chaotic workflows into strict, reliable, and deeply structured autonomous AI architectures."
+        items: [
+            "Exact Sciences",
+            "Engineering",
+            "Artificial Intelligence (AI)"
+        ]
+    },
+    {
+        title: "The Metaphysical & Diagnostic Core",
+        icon: Sparkles,
+        color: "text-idan-david-aviv-purple",
+        bg: "bg-idan-david-aviv-purple/10",
+        border: "border-idan-david-aviv-purple/20",
+        items: [
+            "Classical Kabbalah (Zohar, Sefer Yetzira, HaARI)",
+            "Practical Kabbalah (Shap-Tie Method)",
+            "Astrology",
+            "Numerology"
+        ]
     }
 ]
 
 export default function WorldOfInterests() {
-    const [openId, setOpenId] = useState<string | null>(null);
-
-    const toggleInterest = (id: string) => {
-        setOpenId(openId === id ? null : id);
-    };
+    const [isOpen, setIsOpen] = useState(false);
 
     return (
         <Section id="world-of-interests" className="pb-32 px-6">
-            <div className="w-full max-w-4xl mx-auto flex flex-col items-center">
-                <div className="text-center mb-12 space-y-4">
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight text-white/90">
-                        World of Interests
-                    </h2>
-                    <p className="text-white/50 text-lg font-light max-w-2xl mx-auto">
-                        The multidimensional fields driving the underlying architecture.
-                    </p>
-                </div>
-
-                <div className="w-full space-y-4">
-                    {INTERESTS.map((interest) => (
-                        <div
-                            key={interest.id}
-                            className="w-full rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden transition-all duration-300"
-                        >
-                            <button
-                                onClick={() => toggleInterest(interest.id)}
-                                className={cn(
-                                    "w-full flex items-center justify-between p-6 cursor-pointer hover:bg-white/[0.04] transition-colors",
-                                    openId === interest.id && "bg-white/[0.04]"
-                                )}
-                            >
-                                <div className="flex items-center gap-4">
-                                    <div className={cn("p-3 rounded-xl", interest.bg, interest.border, "border")}>
-                                        <interest.icon className={cn("w-6 h-6", interest.color)} />
-                                    </div>
-                                    <h3 className="text-lg md:text-xl font-medium text-white/90">
-                                        {interest.title}
-                                    </h3>
-                                </div>
-                                <motion.div
-                                    animate={{ rotate: openId === interest.id ? 180 : 0 }}
-                                    transition={{ duration: 0.3 }}
-                                    className="p-2"
-                                >
-                                    <ChevronDown className="w-5 h-5 text-white/40" />
-                                </motion.div>
-                            </button>
-
-                            <AnimatePresence>
-                                {openId === interest.id && (
-                                    <motion.div
-                                        initial={{ height: 0, opacity: 0 }}
-                                        animate={{ height: "auto", opacity: 1 }}
-                                        exit={{ height: 0, opacity: 0 }}
-                                        transition={{ duration: 0.3, ease: "easeInOut" }}
-                                    >
-                                        <div className="p-6 pt-0 text-white/60 leading-relaxed font-light">
-                                            {interest.content}
-                                        </div>
-                                    </motion.div>
-                                )}
-                            </AnimatePresence>
+            <div className="w-full max-w-5xl mx-auto flex flex-col items-center">
+                
+                <div className="w-full rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden transition-all duration-500">
+                    {/* The Single Collapsible Header */}
+                    <button
+                        onClick={() => setIsOpen(!isOpen)}
+                        className={cn(
+                            "w-full flex items-center justify-between p-6 md:p-8 cursor-pointer hover:bg-white/[0.04] transition-colors",
+                            isOpen && "bg-white/[0.04]"
+                        )}
+                    >
+                        <div className="flex items-center gap-4">
+                            <div className="p-3 rounded-xl bg-white/5 border border-white/10">
+                                <Brain className="w-6 h-6 text-white/80" />
+                            </div>
+                            <div className="text-left">
+                                <h3 className="text-xl md:text-2xl font-medium text-white/90">
+                                    World of Interests
+                                </h3>
+                                <p className="text-white/50 text-sm md:text-base font-light mt-1">
+                                    Expand to explore the multidimensional knowledge architecture
+                                </p>
+                            </div>
                         </div>
-                    ))}
+                        <motion.div
+                            animate={{ rotate: isOpen ? 180 : 0 }}
+                            transition={{ duration: 0.3 }}
+                            className="p-2"
+                        >
+                            <ChevronDown className="w-6 h-6 text-white/40" />
+                        </motion.div>
+                    </button>
+
+                    {/* The Expanded Content Area */}
+                    <AnimatePresence>
+                        {isOpen && (
+                            <motion.div
+                                initial={{ height: 0, opacity: 0 }}
+                                animate={{ height: "auto", opacity: 1 }}
+                                exit={{ height: 0, opacity: 0 }}
+                                transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }} // smooth spring-like ease
+                            >
+                                <div className="p-6 md:p-8 pt-0 border-t border-white/5 mt-4">
+                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
+                                        {KNOWLEDGE_STRUCTURE.map((group, idx) => (
+                                            <div key={idx} className="flex flex-col space-y-4">
+                                                {/* Group Header */}
+                                                <div className="flex items-center gap-3">
+                                                    <div className={cn("p-2 rounded-lg", group.bg, group.border, "border")}>
+                                                        <group.icon className={cn("w-4 h-4", group.color)} />
+                                                    </div>
+                                                    <h4 className="text-white/80 font-medium text-sm tracking-wide uppercase">
+                                                        {group.title}
+                                                    </h4>
+                                                </div>
+                                                
+                                                {/* Items List */}
+                                                <ul className="flex flex-col space-y-2">
+                                                    {group.items.map((item, i) => (
+                                                        <li key={i} className="flex items-start gap-2 text-white/60 text-sm leading-relaxed font-light">
+                                                            <span className="text-white/20 mt-1">•</span>
+                                                            {item}
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
                 </div>
             </div>
         </Section>

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -102,16 +102,18 @@ export default function WorldOfInterests() {
                                         {KNOWLEDGE_STRUCTURE.map((group, idx) => (
                                             <div key={idx} className="flex flex-col space-y-4">
                                                 {/* Group Header */}
-                                                <div className="flex flex-col items-center text-center space-y-1 mb-3">
-                                                    <div className={cn("p-2 rounded-lg mb-2", group.bg, group.border, "border")}>
-                                                        <group.icon className={cn("w-5 h-5", group.color)} />
-                                                    </div>
+                                                <div className="flex flex-col space-y-3 mb-2">
                                                     <span className={cn("text-[11px] font-bold tracking-[0.2em] uppercase opacity-80", group.color)}>
                                                         {group.supTitle}
                                                     </span>
-                                                    <h4 className="text-white/90 font-medium text-[13px] tracking-wide uppercase">
-                                                        {group.title}
-                                                    </h4>
+                                                    <div className="flex items-center gap-3">
+                                                        <div className={cn("p-2 rounded-lg", group.bg, group.border, "border")}>
+                                                            <group.icon className={cn("w-4 h-4", group.color)} />
+                                                        </div>
+                                                        <h4 className="text-white/90 font-medium text-[13px] tracking-wide uppercase">
+                                                            {group.title}
+                                                        </h4>
+                                                    </div>
                                                 </div>
                                                 
                                                 {/* Items List */}

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -16,7 +16,7 @@ const KNOWLEDGE_STRUCTURE = [
             "Nature and people",
             "Natural Sciences",
             "The Human Mind & Human Experience",
-            "Emotional Work"
+
         ]
     },
     {
@@ -27,11 +27,10 @@ const KNOWLEDGE_STRUCTURE = [
         bg: "bg-idan-david-aviv-cyan/10",
         border: "border-idan-david-aviv-cyan/20",
         items: [
-            "Exact Sciences",
-            "Engineering",
             "Artificial Intelligence (AI)",
-            "Software & Hardware Architectures",
-            "Systemic Thinking & Design"
+            "Data Science, Machine & Deep Learning",
+            "Software & System Architectures",
+            "Exact Sciences & Engineering"
         ]
     },
     {
@@ -42,10 +41,9 @@ const KNOWLEDGE_STRUCTURE = [
         bg: "bg-idan-david-aviv-purple/10",
         border: "border-idan-david-aviv-purple/20",
         items: [
-            "Classical Kabbalah (Zohar, Sefer Yetzira, HaARI)",
-            "Practical Kabbalah (Shabtay Method)",
-            "Astrology",
-            "Numerology"
+            "Emotional Work & Intuition",
+            "Classical & Practical Kabbalah",
+            "Astrology & Numerology"
         ]
     }
 ]
@@ -56,7 +54,7 @@ export default function WorldOfInterests() {
     return (
         <Section id="world-of-interests" className="pb-32 px-6">
             <div className="w-full max-w-5xl mx-auto flex flex-col items-center">
-                
+
                 <div className="w-full rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden transition-all duration-500">
                     {/* The Single Collapsible Header */}
                     <button
@@ -75,7 +73,10 @@ export default function WorldOfInterests() {
                                     Sources of inspiration
                                 </h3>
                                 <p className="text-white/50 text-sm md:text-base font-light mt-1">
-                                    Expand to explore the multidimensional knowledge architecture
+                                    On my quest to discover the world, I find many points of view and fields of interest. <br />
+                                    They often interact in unexpected ways, and help me look deeper into the misteries of life, the universe, and everything.
+                                    <br />
+                                    I invite you to take a look, and maybe you&apos;ll find something interesting/inspiring to you as well.
                                 </p>
                             </div>
                         </div>
@@ -97,7 +98,7 @@ export default function WorldOfInterests() {
                                 exit={{ height: 0, opacity: 0 }}
                                 transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }} // smooth spring-like ease
                             >
-                                <div className="p-6 md:p-8 pt-0 border-t border-white/5 mt-4">
+                                <div className="p-6 md:p-8 pt-0 mt-4">
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
                                         {KNOWLEDGE_STRUCTURE.map((group, idx) => (
                                             <div key={idx} className="flex flex-col space-y-4">
@@ -115,7 +116,7 @@ export default function WorldOfInterests() {
                                                         </h4>
                                                     </div>
                                                 </div>
-                                                
+
                                                 {/* Items List */}
                                                 <ul className="flex flex-col space-y-2">
                                                     {group.items.map((item, i) => (

--- a/src/components/sections/WorldOfInterests.tsx
+++ b/src/components/sections/WorldOfInterests.tsx
@@ -7,19 +7,21 @@ import { cn } from '@/lib/utils'
 const KNOWLEDGE_STRUCTURE = [
     {
         title: "The Biological & Behavioral Core",
+        subtitle: "The Source",
         icon: Activity,
         color: "text-idan-david-aviv-blue",
         bg: "bg-idan-david-aviv-blue/10",
         border: "border-idan-david-aviv-blue/20",
         items: [
-            "Life Sciences",
-            "Soft Sciences",
-            "Human Mind & Human Experience",
-            "Mental Health & Emotional Work"
+            "Nature and people",
+            "Natural Sciences",
+            "The Human Mind & Human Experience",
+            "Emotional Work"
         ]
     },
     {
         title: "The Structural & Systems Core",
+        subtitle: "The Body",
         icon: Dna,
         color: "text-idan-david-aviv-cyan",
         bg: "bg-idan-david-aviv-cyan/10",
@@ -27,18 +29,21 @@ const KNOWLEDGE_STRUCTURE = [
         items: [
             "Exact Sciences",
             "Engineering",
-            "Artificial Intelligence (AI)"
+            "Artificial Intelligence (AI)",
+            "Software & Hardware Architectures",
+            "Systemic Thinking & Design"
         ]
     },
     {
         title: "The Metaphysical & Diagnostic Core",
+        subtitle: "The Context",
         icon: Sparkles,
         color: "text-idan-david-aviv-purple",
         bg: "bg-idan-david-aviv-purple/10",
         border: "border-idan-david-aviv-purple/20",
         items: [
             "Classical Kabbalah (Zohar, Sefer Yetzira, HaARI)",
-            "Practical Kabbalah (Shap-Tie Method)",
+            "Practical Kabbalah (Shabtay Method)",
             "Astrology",
             "Numerology"
         ]
@@ -67,7 +72,7 @@ export default function WorldOfInterests() {
                             </div>
                             <div className="text-left">
                                 <h3 className="text-xl md:text-2xl font-medium text-white/90">
-                                    World of Interests
+                                    Sources of inspiration
                                 </h3>
                                 <p className="text-white/50 text-sm md:text-base font-light mt-1">
                                     Expand to explore the multidimensional knowledge architecture
@@ -97,13 +102,16 @@ export default function WorldOfInterests() {
                                         {KNOWLEDGE_STRUCTURE.map((group, idx) => (
                                             <div key={idx} className="flex flex-col space-y-4">
                                                 {/* Group Header */}
-                                                <div className="flex items-center gap-3">
-                                                    <div className={cn("p-2 rounded-lg", group.bg, group.border, "border")}>
-                                                        <group.icon className={cn("w-4 h-4", group.color)} />
+                                                <div className="flex flex-col items-center text-center space-y-2 mb-2">
+                                                    <div className={cn("p-2 rounded-lg mb-1", group.bg, group.border, "border")}>
+                                                        <group.icon className={cn("w-5 h-5", group.color)} />
                                                     </div>
-                                                    <h4 className="text-white/80 font-medium text-sm tracking-wide uppercase">
+                                                    <h4 className="text-white/90 font-medium text-[13px] tracking-wide uppercase">
                                                         {group.title}
                                                     </h4>
+                                                    <span className={cn("text-[11px] font-bold tracking-[0.2em] uppercase opacity-80", group.color)}>
+                                                        {group.subtitle}
+                                                    </span>
                                                 </div>
                                                 
                                                 {/* Items List */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import Hero from '@/components/sections/Hero'
 import About from '@/components/sections/About'
-import WorkGrid from '@/components/sections/WorkGrid'
+import MainProjects from '@/components/sections/MainProjects'
 import WorldOfInterests from '@/components/sections/WorldOfInterests'
 import Contact from '@/components/sections/Contact'
 
@@ -12,7 +12,7 @@ export default function Home() {
         <main className="w-full relative z-10 flex flex-col items-center bg-transparent">
             <Hero />
             <About />
-            <WorkGrid />
+            <MainProjects />
             <WorldOfInterests />
             <Contact />
         </main>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import Hero from '@/components/sections/Hero'
 import About from '@/components/sections/About'
 import WorkGrid from '@/components/sections/WorkGrid'
+import WorldOfInterests from '@/components/sections/WorldOfInterests'
 import Contact from '@/components/sections/Contact'
 
 /**
@@ -12,6 +13,7 @@ export default function Home() {
             <Hero />
             <About />
             <WorkGrid />
+            <WorldOfInterests />
             <Contact />
         </main>
     )


### PR DESCRIPTION
This PR introduces:

1. **World of Interests Redesign**: Re-architected `WorldOfInterests.tsx` into a single, high-fidelity expandable vertical block. Categories are now split into biological/behavioral, structural/systems, and metaphysical/diagnostic with exact mappings.
2. **MainProjects Refactor**: Renamed `WorkGrid.tsx` to `MainProjects.tsx` per the updated UI.
3. **Core Blueprint Synchronization**: Locked the precise knowledge fields into the permanent `idan_core_blueprint` for future reference.